### PR TITLE
GH-1: Fix spring.metrics.export.includes in tests

### DIFF
--- a/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/AbstractCounterSinkTests.java
+++ b/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/AbstractCounterSinkTests.java
@@ -39,26 +39,25 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @author Mark Pollack
  * @author Marius Bogoevici
  * @author Gary Russell
+ * @author Artem Bilan
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 		properties = {
 				"spring.metrics.export.delayMillis:10",
-				"classes:AbstractCounterSinkTests.CounterSinkApplication.class" })
+				"spring.metrics.export.includes:"})
 @DirtiesContext
 public abstract class AbstractCounterSinkTests {
 
 	@Rule
 	public RedisTestSupport redisAvailableRule = new RedisTestSupport();
 
-	protected int sleepTime = 100;
-
 	@Autowired
 	protected Sink sink;
 
 	@Autowired
 	@Qualifier("metricRepository")
-	protected MetricRepository redisMetricRepository;
+	private MetricRepository redisMetricRepository;
 
 	@Before
 	public void init() {
@@ -69,6 +68,10 @@ public abstract class AbstractCounterSinkTests {
 	@After
 	public void clear() {
 		this.redisMetricRepository.reset("counter.simpleCounter");
+	}
+
+	protected MetricRepository getRedisMetricRepository() {
+		return this.redisMetricRepository;
 	}
 
 	@SpringBootApplication

--- a/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkDefaultNameTests.java
+++ b/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkDefaultNameTests.java
@@ -16,16 +16,26 @@
 
 package org.springframework.cloud.stream.app.counter.sink;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.springframework.integration.test.matcher.EqualsResultMatcher.equalsResult;
+import static org.springframework.integration.test.matcher.EventuallyMatcher.eventually;
 
 import org.junit.Test;
 
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.integration.test.matcher.EqualsResultMatcher;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.TestPropertySource;
 
-@TestPropertySource(properties = "spring.application.name:simpleCounter" )
+/**
+ * @author Mark Pollack
+ * @author Marius Bogoevici
+ * @author Gary Russell
+ * @author Artem Bilan
+ */
+@TestPropertySource(properties = "spring.application.name:simpleCounter")
 public class CounterSinkDefaultNameTests extends AbstractCounterSinkTests {
 
 	@Test
@@ -33,11 +43,19 @@ public class CounterSinkDefaultNameTests extends AbstractCounterSinkTests {
 		assertNotNull(this.sink.input());
 		Message<String> message = MessageBuilder.withPayload("...").build();
 		sink.input().send(message);
-		Thread.sleep(sleepTime);
+
 		// Note: If the name of the counter does not start with 'counter' or 'metric' the
 		// 'counter.' prefix is added
-		// by the DefaultCounterService
-		assertEquals(1, this.redisMetricRepository.findOne("counter.simpleCounter").getValue().longValue());
+		// by the DefaultCounterService and BufferCounterService
+		assertThat(1L, eventually(equalsResult(new EqualsResultMatcher.Evaluator<Long>() {
+
+			@Override
+			public Long evaluate() {
+				Metric<?> metric = getRedisMetricRepository().findOne("counter.simpleCounter");
+				return metric != null ? metric.getValue().longValue() : null;
+			}
+
+		})));
 	}
 
 }

--- a/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkNameTests.java
+++ b/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkNameTests.java
@@ -16,15 +16,25 @@
 
 package org.springframework.cloud.stream.app.counter.sink;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.springframework.integration.test.matcher.EqualsResultMatcher.equalsResult;
+import static org.springframework.integration.test.matcher.EventuallyMatcher.eventually;
 
 import org.junit.Test;
 
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.integration.test.matcher.EqualsResultMatcher;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.TestPropertySource;
 
+/**
+ * @author Mark Pollack
+ * @author Marius Bogoevici
+ * @author Gary Russell
+ * @author Artem Bilan
+ */
 @TestPropertySource(properties = "counter.name:simpleCounter")
 public class CounterSinkNameTests extends AbstractCounterSinkTests {
 
@@ -33,11 +43,19 @@ public class CounterSinkNameTests extends AbstractCounterSinkTests {
 		assertNotNull(this.sink.input());
 		Message<String> message = MessageBuilder.withPayload("Hi").build();
 		sink.input().send(message);
-		Thread.sleep(sleepTime);
+
 		// Note: If the name of the counter does not start with 'counter' or 'metric' the
 		// 'counter.' prefix is added
-		// by the DefaultCounterService
-		assertEquals(1, this.redisMetricRepository.findOne("counter.simpleCounter").getValue().longValue());
+		// by the DefaultCounterService and BufferCounterService
+		assertThat(1L, eventually(equalsResult(new EqualsResultMatcher.Evaluator<Long>() {
+
+			@Override
+			public Long evaluate() {
+				Metric<?> metric = getRedisMetricRepository().findOne("counter.simpleCounter");
+				return metric != null ? metric.getValue().longValue() : null;
+			}
+
+		})));
 	}
 
 }


### PR DESCRIPTION
Fixes spring-cloud-stream-app-starters/counter#1

The new SCSt has `BinderMetricsEnvironmentPostProcessor` which
populates `"spring.metrics.export.includes", "integration**"` property
That doesn't let our test `counter.simpleCounter` metric to be written
to the repository

* Add `spring.metrics.export.includes:` property to tests to override
`BinderMetricsEnvironmentPostProcessor` stuff
* Polishing for tests to use `eventually()` matcher instead of
"magic" `Thread.sleep()`