### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-starter-stream-sink-counter/src/main/java/org/springframework/cloud/stream/app/counter/sink/CounterProperties.java
+++ b/spring-cloud-starter-stream-sink-counter/src/main/java/org/springframework/cloud/stream/app/counter/sink/CounterProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-counter/src/main/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-counter/src/main/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-counter/src/main/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkStoreConfiguration.java
+++ b/spring-cloud-starter-stream-sink-counter/src/main/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkStoreConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/AbstractCounterSinkTests.java
+++ b/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/AbstractCounterSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkDefaultNameTests.java
+++ b/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkDefaultNameTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkExpressionNameTests.java
+++ b/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkExpressionNameTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkNameTests.java
+++ b/spring-cloud-starter-stream-sink-counter/src/test/java/org/springframework/cloud/stream/app/counter/sink/CounterSinkNameTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 7 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).